### PR TITLE
Use Pervasives.stdin

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -168,7 +168,7 @@ let init_config () =
   ]
   in
   Arg.parse (Arg.align options) add_file usage;
-  Util.default "/dev/stdin" !file, !lines, !numeric_only, !indent, !debug
+  !file, !lines, !numeric_only, !indent, !debug
 
 let file, lines, numeric_only, indent, debug = init_config ()
 

--- a/src/config.mli
+++ b/src/config.mli
@@ -50,7 +50,7 @@ end
 
 (* Current configuration: *)
 
-val file: string
+val file: string option
 val lines: int option * int option
 val numeric_only: bool
 val indent: Indent.t

--- a/src/main.ml
+++ b/src/main.ml
@@ -18,7 +18,12 @@ open Nstream
 open Approx_lexer
 open Util
 
-let stream = Nstream.create Config.file
+let stream =
+  let ic = match Config.file with
+    | None -> stdin
+    | Some f -> open_in f
+  in
+  Nstream.create ic
 
 (* utility functions *)
 

--- a/src/nstream.ml
+++ b/src/nstream.ml
@@ -33,8 +33,7 @@ type cons =
 
 and t = cons lazy_t
 
-let create path =
-  let ic = open_in path in
+let create ic =
   try
     let reader = LexReader.create_from_channel ic in
     let rec loop last =

--- a/src/nstream.mli
+++ b/src/nstream.mli
@@ -31,7 +31,7 @@ type token = {
 type t
 
 (** Create a filter *)
-val create: string -> t
+val create: in_channel -> t
 
 (** Close a filter *)
 val close: t -> unit


### PR DESCRIPTION
Makes it possible to use ocp-indent directly in acme
