### PR TITLE
Vim bindings (#24)

### DIFF
--- a/tools/ocp-indent.vim
+++ b/tools/ocp-indent.vim
@@ -2,9 +2,10 @@
 "It binds <LocalLeader>i to the ocp-indent filter.
 "It creates the OCPIndent command.
 
-:vnoremap <LocalLeader>i <ESC>:'<,'>!ocp-indent<CR>
-:nnoremap <LocalLeader>i :%!ocp-indent<CR>
+vnoremap <LocalLeader>i <ESC>:'<,'>!ocp-indent<CR>
+nnoremap <LocalLeader>i :%!ocp-indent<CR>
 command! -range=% OCPIndent :<line1>,<line2>!ocp-indent
+setlocal equalprg=ocp-indent
 
 
 "How to use:


### PR DESCRIPTION
Three little commands to make ocp-indent invocation trivial.

Fixes Issue #24
