### PR TITLE
Allow tab for indentation

### DIFF
--- a/src/indentConfig.ml
+++ b/src/indentConfig.ml
@@ -14,7 +14,7 @@
 (**************************************************************************)
 
   type t = {
-    i_atom: string;
+    i_atom: char;
     i_base: int;
     i_type: int;
     i_in: int;
@@ -23,16 +23,16 @@
   }
 
   let default = {
-    i_atom = "  ";
-    i_base = 1;
-    i_type = 1;
+    i_atom = ' ';
+    i_base = 2;
+    i_type = 2;
     i_in = 0;
     i_with = 0;
-    i_match_clause = 1;
+    i_match_clause = 2;
   }
   
   let tab = {
-    i_atom = "\t";
+    i_atom = '\t';
     i_base = 1;
     i_type = 1;
     i_in = 0;
@@ -42,18 +42,22 @@
 
   let presets = [
     "apprentice",
-    { i_atom = "  "; i_base = 2; i_with = 1; i_in = 1; i_match_clause = 2; i_type = 2 };
+    { i_atom = ' '; i_base = 4; i_with = 2; i_in = 2; i_match_clause = 4; i_type = 4 };
     "normal",
     default;
     "JaneStreet",
-    { i_atom = "  "; i_base = 1; i_with = 0; i_in = 0; i_match_clause = 1; i_type = 0 };
+    { i_atom = ' '; i_base = 2; i_with = 0; i_in = 0; i_match_clause = 2; i_type = 0 };
     "tab", tab
   ]
 
   let set t var_name value =
     try
       match var_name with
-      | "atom" -> {t with i_atom = value}
+      | "atom" ->
+        if String.length value = 1 then
+          {t with i_atom = value.[0]}
+        else
+          raise (Invalid_argument "Atom takes one character")
       | "base" -> {t with i_base = int_of_string value}
       | "type" -> {t with i_type = int_of_string value}
       | "in" -> {t with i_in = int_of_string value}
@@ -82,7 +86,7 @@
        \n\
        Indent configuration variables:\n\
       \  [variable]   [default] [help]\n\
-      \  atom           \"%s\"    %sindentation string\n\     
+      \  atom           '%c'    indentation atom\n\     
       \  base           %3d     base indent\n\
       \  type           %3d     indent of type definitions\n\
       \  in             %3d     indent after 'let in'\n\
@@ -92,7 +96,7 @@
        Available configuration presets:%s\n\
        \n\
        The config can also be set in variable OCP_INDENT_CONFIG"
-      default.i_atom default.i_atom
+      default.i_atom
       default.i_base
       default.i_type
       default.i_in

--- a/src/indentConfig.mli
+++ b/src/indentConfig.mli
@@ -15,12 +15,12 @@
 
   type t = {
     (* the indentation string: what is put as a base string
-       default "  " *)
-    i_atom: string;
+       default ' ' *)
+    i_atom: char;
     (* number of spaces used in all base cases, for example:
        let foo =
        ^^bar
-       default 1 *)
+       default 2 *)
     i_base: int;
     (* indent for type definitions:
        type t =
@@ -41,7 +41,7 @@
        match foo with
          | _ ->
          ^^bar
-       default 1, which aligns the pattern and the expression *)
+       default 2, which aligns the pattern and the expression *)
     i_match_clause: int;
   }
 

--- a/src/indentPrinter.ml
+++ b/src/indentPrinter.ml
@@ -35,13 +35,7 @@ let pr_nl oc =
     flush stdout
 
 let indentation_string indent =
-  let t = !IndentArgs.arg_indent in
-  let l = String.length t.IndentConfig.i_atom in
-  let s = String.make (l * indent) ' ' in
-  for i=0 to indent - 1 do
-    String.blit t.IndentConfig.i_atom 0 s (i * l) l
-  done ;
-  s 
+  String.make indent !IndentArgs.arg_indent.IndentConfig.i_atom
   
 
 (* indent functions *)


### PR DESCRIPTION
By adding one field to the IndentConfig.t records, it is possible to customize the indentation character.

Note that using only the first commit (instead of both), makes it possible to 
use any arbitrary string (might be useful to pretty-print indentation levels 
as in

```
let look ma =
!  these
!  !  are
!  !  indentation
!  !  level;
!  (admittedly not that useful)
```
