### PR TITLE
Add "partial" case to -with-never option

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -532,7 +532,7 @@ let update_path config t stream tok =
       open_paren KBrace t.path
   | FUNCTION ->
       (match fold_expr t.path with
-       | l :: _ as p when not starts_line && not config.i_with_never ->
+       | l :: _ as p when not starts_line && config.i_with_never = False ->
            append (KWith KMatch) L ~pad:(max l.pad config.i_with) p
        | p ->
            append (KWith KMatch) L ~pad:config.i_with p)
@@ -669,10 +669,13 @@ let update_path config t stream tok =
                 | _ ->
                     append (KWith KBrace) L ~pad:(pad + config.i_with) path)
            | {k=KVal|KType|KException as k}::_ -> replace (KWith k) L path
-           | {k=KTry|KMatch} as n :: {pad} :: _
+           | {k=KTry|KMatch} as n :: {pad;k} :: _
              when n.line = Region.start_line tok.region
                && n.t <> n.l
-               && not config.i_with_never
+               && match config.i_with_never with
+                  | True -> false
+                  | False -> true
+                  | Partial -> k <> KBegin || k <> KParen
              ->
                replace (KWith KMatch)
                  L ~pad:(max pad config.i_with)

--- a/src/indentConfig.ml
+++ b/src/indentConfig.ml
@@ -15,12 +15,17 @@
 
 open Compat
 
+type with_never =
+  | True
+  | False
+  | Partial
+
 type t = {
   i_base: int;
   i_type: int;
   i_in: int;
   i_with: int;
-  i_with_never: bool;
+  i_with_never: with_never;
   i_match_clause: int;
 }
 
@@ -29,20 +34,31 @@ let default = {
   i_type = 2;
   i_in = 0;
   i_with = 0;
-  i_with_never = false;
+  i_with_never = False;
   i_match_clause = 2;
 }
 
 let presets = [
   "apprentice",
   { i_base = 2; i_type = 4; i_in = 2;
-    i_with = 2; i_with_never = false; i_match_clause = 4 };
+    i_with = 2; i_with_never = False; i_match_clause = 4 };
   "normal",
   default;
   "JaneStreet",
   { i_base = 2; i_type = 0; i_in = 0;
-    i_with = 0; i_with_never = false; i_match_clause = 2 };
+    i_with = 0; i_with_never = False; i_match_clause = 2 };
 ]
+
+let with_never_of_string s = match String.lowercase s with
+  | "true" | "yes" | "1" | "always" -> True
+  | "false" | "no" | "0" | "never" -> False
+  | "partial" -> Partial
+  | _ -> raise (Failure "with_never_of_string")
+
+let string_of_with_never () = function
+  | True -> "true"
+  | False -> "false"
+  | Partial -> "partial"
 
 let set t var_name value =
   try
@@ -51,7 +67,7 @@ let set t var_name value =
     | "type" -> {t with i_type = int_of_string value}
     | "in" -> {t with i_in = int_of_string value}
     | "with" -> {t with i_with = int_of_string value}
-    | "with_never" -> {t with i_with_never = bool_of_string value}
+    | "with_never" -> {t with i_with_never = with_never_of_string value}
     | "match_clause" -> {t with i_match_clause = int_of_string value}
     | _ -> raise (Invalid_argument var_name)
   with
@@ -60,6 +76,10 @@ let set t var_name value =
       raise (Invalid_argument e)
   | Failure "bool_of_string" ->
       let e = Printf.sprintf "%S should be either \"true\" or \"false\"" value
+      in
+      raise (Invalid_argument e)
+  | Failure "with_never_of_string" ->
+      let e = Printf.sprintf "%S should be either \"true\", \"false\" or \"partial\"" value
       in
       raise (Invalid_argument e)
 
@@ -84,7 +104,7 @@ let help =
     \  type           %3d     indent of type definitions\n\
     \  in             %3d     indent after 'let in'\n\
     \  with           %3d     indent of match cases (before '|')\n\
-    \  with_never     %b   respect 'with' even when not starting line\n\
+    \  with_never     %a   respect 'with' even when not starting line\n\
     \  match_clause   %3d     indent inside match cases (after '->')\n\
      \n\
      Available configuration presets:%s\n\
@@ -94,7 +114,7 @@ let help =
     default.i_type
     default.i_in
     default.i_with
-    default.i_with_never
+    string_of_with_never default.i_with_never
     default.i_match_clause
     (List.fold_left (fun s (name,_) -> s ^ " " ^ name) "" presets)
 

--- a/src/indentConfig.mli
+++ b/src/indentConfig.mli
@@ -13,6 +13,11 @@
 (*                                                                        *)
 (**************************************************************************)
 
+type with_never =
+  | True
+  | False
+  | Partial
+
 type t = {
   (* number of spaces used in all base cases, for example:
      let foo =
@@ -37,8 +42,9 @@ type t = {
   (* if set, indent for [with] will be strictly respected even if not starting
      the line. Useful with [i_with=0] if you don't want to indent after
      let f = function
-     default false *)
-  i_with_never: bool;
+     If set to partial, apply this rule only after begin match.
+     default False *)
+  i_with_never: with_never;
   (* indent for clauses inside a pattern-match:
      match foo with
        | _ ->


### PR DESCRIPTION
It does not indent the begin when writing
begin match ... with
