### PR TITLE
small fix to the vim plugin

### DIFF
--- a/tools/ocp-indent.vim
+++ b/tools/ocp-indent.vim
@@ -26,7 +26,7 @@ function! OcpIndentBuffer()
 endfunction
 
 
-vnoremap <LocalLeader>i :call OcpIndentRange()<CR>
-nnoremap <LocalLeader>i :call OcpIndentBuffer()<CR>
-map == :call OcpIndentRange()<CR>
-vnoremap = :call OcpIndentRange()<CR>
+au FileType ocaml vnoremap <LocalLeader>i :call OcpIndentRange()<CR>
+au FileType ocaml nnoremap <LocalLeader>i :call OcpIndentBuffer()<CR>
+au FileType ocaml map == :call OcpIndentRange()<CR>
+au FileType ocaml vnoremap = :call OcpIndentRange()<CR>


### PR DESCRIPTION
be a good citizen and remap indentation to use ocp-indent only for ocaml
files.
