### PR TITLE
Add provide declaration to ocp-indent.el

### DIFF
--- a/tools/ocp-indent.el
+++ b/tools/ocp-indent.el
@@ -1,6 +1,7 @@
 ;; Eval this file to automatically use ocp-indent on caml/tuareg buffers
 ;;
 
+(provide 'ocp-indent)
 (require 'cl)
 
 (defgroup ocp-indent nil


### PR DESCRIPTION
Without this, you can't include ocp-indent with a simple (require 'ocp-indent) declaration
