### PR TITLE
Handling new string syntax {xx| |xx}

### DIFF
--- a/src/indentPrinter.ml
+++ b/src/indentPrinter.ml
@@ -152,7 +152,11 @@ let print_token output block tok usr =
                     start_column + n
                 | QUOTATION ->
                     start_column +
-                      if next_lines = [] && text = ">>" then 0
+                      if next_lines = [] &&
+                         (text = ">>" ||
+                          (String.length text >= 2 &&
+                           text.[0] = '|' && text.[String.length text - 1] = '}'))
+                      then 0
                       else max orig_offset pad
                 | _ -> start_column + max orig_offset pad
           in
@@ -184,9 +188,14 @@ let print_token output block tok usr =
       | OCAMLDOC_VERB -> None
       | QUOTATION ->
           let i = ref 1 in
-          while !i < String.length text && text.[!i] <> '<' do incr i done;
-          if !i + 1 >= String.length text then Some 2
-          else Some (!i + 1)
+          let len = String.length text in
+          let endc = if len > 0 && text.[0] = '{' then '|' else '<' in
+          while !i < len && text.[!i] <> endc do incr i done;
+          if !i + 1 >= len then None
+          else (
+            incr i; while !i < len && text.[!i] = ' ' do incr i done;
+            Some !i
+          )
       | _ -> Some 2
   in
   usr

--- a/tests/failing.html
+++ b/tests/failing.html
@@ -2,7 +2,7 @@
  "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html>
 <head>
-    <title>Failing tests, ocp-indent version 1.4.0+9 (2013-09-25)</title>
+    <title>Failing tests, ocp-indent version 1.4.0+2 (2013-11-25)</title>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
     <style>
       TABLE { border-collapse: collapse; border-spacing: 0px; margin: auto; }
@@ -16,7 +16,7 @@
     </style>
 </head>
 <body>
-<h1>Failing tests, ocp-indent version 1.4.0+9 (2013-09-25)</h1>
+<h1>Failing tests, ocp-indent version 1.4.0+2 (2013-11-25)</h1>
 <div>
 <h2>Differences in js-args.ml</h2>
 <table>


### PR DESCRIPTION
Using the same mechanism as for camlp4 quotations. Indent is free, only forcing to respect
the left margin unless starting with {xx|\n
Ref: #100
