### PR TITLE
Correct OPAM post-message for vim plugin.

### DIFF
--- a/opam
+++ b/opam
@@ -21,7 +21,11 @@ To use it from emacs, add the following to your .emacs:
   (require 'ocp-indent)
 
 To use it from Vim, add to your .vimrc:
-  autocmd FileType ocaml source
-    (system(\"opam config var share\").\"/emacs/site-lisp/ocp-indent.vim\")"
+  let g:ocp_indent_vimfile = system(\"opam config var share\")
+  let g:ocp_indent_vimfile = substitute(g:ocp_indent_vimfile, '[\\r\\n]*$', '', '')
+  let g:ocp_indent_vimfile = g:ocp_indent_vimfile . \"/vim/syntax/ocp-indent.vim\"
+
+  autocmd FileType ocaml exec \":source \" . g:ocp_indent_vimfile
+"
   {success}
 ]


### PR DESCRIPTION
- Fixes path to use correct path `/vim/syntax/ocp-indent.vim`, like `Makefile`.
- Fixes vim invalid syntax on L25.
- Filters newline returned from `system("opam config var share")`.
- Retains `opam config var share` environment.

Output:

![2014-01-09-095326_5206x1080_scrot](https://f.cloud.github.com/assets/26336/1874451/f2d27a8c-78d0-11e3-8ad4-a64763200881.png)
