### PR TITLE
syntax: add support for `bitstring'

### DIFF
--- a/src/approx_lexer.mll
+++ b/src/approx_lexer.mll
@@ -103,7 +103,10 @@ let syntax_extensions = [
   ];
   "cstruct", [
     "cstruct", TYPE;
-  ]
+  ];
+  "bitstring", [
+    "bitmatch", MATCH;
+  ];
 ]
 
 let keyword_table =


### PR DESCRIPTION
Add support for the `bitmatch' syntax extension of the ocaml-bitstring (https://code.google.com/p/bitstring/) library.
