### PR TITLE
Add support for MetaOCaml staging annotations

### DIFF
--- a/src/approx_lexer.mll
+++ b/src/approx_lexer.mll
@@ -446,6 +446,8 @@ rule token = parse
   | "->" { MINUSGREATER }
   | "."  { DOT }
   | ".." { DOTDOT }
+  | ".<" { DOTLESS }
+  | ".~" { DOTTILDE }
   | ":"  { COLON }
   | "::" { COLONCOLON }
   | ":=" { COLONEQUAL }
@@ -466,6 +468,7 @@ rule token = parse
   | "||" { BARBAR }
   | "|]" { BARRBRACKET }
   | ">"  { GREATER }
+  | ">." { GREATERDOT }
   | ">]" { GREATERRBRACKET }
   | "}"  { RBRACE }
   | ">}" { GREATERRBRACE }

--- a/src/approx_tokens.ml
+++ b/src/approx_tokens.ml
@@ -53,6 +53,8 @@ type token =
   | DONE
   | DOT
   | DOTDOT
+  | DOTLESS
+  | DOTTILDE
   | DOWNTO
   | ELSE
   | END
@@ -70,6 +72,7 @@ type token =
   | FUNCTION
   | FUNCTOR
   | GREATER
+  | GREATERDOT
   | GREATERRBRACE
   | GREATERRBRACKET
   | IF


### PR DESCRIPTION
The annotations '.<', '>.' are treated like parentheses '(', ')' and the
unary operator '.~' like '!'.

It works fine so far, but I am not very familiar with the indentation engine, so it would be nice if someone could go over the changes and let me know if I missed anything.
