### PR TITLE
New vim plugin by Christopher Zimmerman

### DIFF
--- a/tools/ocp-indent.vim
+++ b/tools/ocp-indent.vim
@@ -1,46 +1,53 @@
-"
-" Copyright 2012-2013 OCamlPro, Raphael Proust, Rudi Grinberg
-"
-" All rights reserved.This file is distributed under the terms of the
-" GNU Lesser General Public License version 3.0 with linking
-" exception.
-"
-" TypeRex is distributed in the hope that it will be useful,
-" but WITHOUT ANY WARRANTY; without even the implied warranty of
-" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-" Lesser GNU General Public License for more details.
-"
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
 
-"
-" Assumes that ocp-indent is in PATH.
-" This can be overriden by setting g:ocp_indent_binary in your .vimrc. Eg.
-"
-" let g:ocp_indent_binary = "/home/jo/bin/ocp-indent.exe"
-"
+setlocal expandtab
+setlocal indentkeys+=0=and,0=class,0=constraint,0=done,0=else,0=end,0=exception,0=external,0=if,0=in,0=include,0=inherit,0=initializer,0=let,0=method,0=open,0=then,0=type,0=val,0=with,0;;,0>\],0\|\],0>},0\|,0},0\],0)
+setlocal nolisp
+setlocal nosmartindent
+setlocal indentexpr=GetOcpIndent(v:lnum)
 
-function! PreserveExec(expr)
-  let l:pos = getpos(".")
-  let l:winview = winsaveview()
-  try
-    execute(a:expr)
-  finally
-    call setpos(".", l:pos)
-    call winrestview(l:winview)
-  endtry
+" Comment formatting
+if !exists("no_ocaml_comments")
+ if (has("comments"))
+   setlocal comments=sr:(*,mb:*,ex:*)
+   setlocal fo=cqort
+ endif
+endif
+
+" Only define the function once.
+if exists("*GetOcpIndent")
+ finish
+endif
+
+let s:indents = []
+let s:buffer = -1
+let s:tick = -1
+let s:line = -1
+"let s:settings = {}
+"let s:settings['base'] = 1
+"let s:settings['type'] = 1
+"let s:settings['in'] = 0
+"let s:settings['with'] = 0
+"let s:settings['match_clause'] = 1
+"let s:settings['ppx_stritem_ext'] = 1
+"let s:settings['max_indent'] = 2
+
+function! GetOcpIndent(lnum)
+  if s:buffer != bufnr('') || s:tick != b:changedtick || s:line > a:lnum
+    let cmdline = "ocp-indent --numeric --lines " . a:lnum . '-'
+    let s:indents = systemlist(cmdline, getline('1','$'))
+    let s:buffer = bufnr('')
+    let s:tick = b:changedtick
+    let s:line = a:lnum
+  elseif s:line < a:lnum
+    call remove(s:indents, 0, a:lnum - s:line - 1)
+    let s:line = a:lnum
+  endif
+
+  let s:line = s:line + 1
+  return remove(s:indents, 0)
 endfunction
-
-function! OcpIndentRange() range
-  let l:ocp_indent_binary = exists("g:ocp_indent_binary") ? g:ocp_indent_binary : "ocp-indent"
-  call PreserveExec(':%!' . l:ocp_indent_binary . ' -l ' . a:firstline . '-' . a:lastline)
-endfunction
-
-function! OcpIndentBuffer()
-  let l:ocp_indent_binary = exists("g:ocp_indent_binary") ? g:ocp_indent_binary : "ocp-indent"
-  call PreserveExec(':%!' . l:ocp_indent_binary)
-endfunction
-
-
-au FileType ocaml vnoremap <LocalLeader>i :call OcpIndentRange()<CR>
-au FileType ocaml nnoremap <LocalLeader>i :call OcpIndentBuffer()<CR>
-au FileType ocaml map <buffer> == :call OcpIndentRange()<CR>
-au FileType ocaml vnoremap = :call OcpIndentRange()<CR>


### PR DESCRIPTION
Quoting his message:

> attached you find a better vim indentation plugin which uses only
> indentexpr and no key mapping, for more intuitive usage. It also
> performs well due to caching.
> It should be installed
> at /usr/(local/)share/vim/vimfiles/indent/ocaml.vim.
> 
> Christopher
