### PR TITLE
Add ocp-indent-buffer to emacs mode

### DIFF
--- a/tools/ocp-indent.el
+++ b/tools/ocp-indent.el
@@ -105,6 +105,10 @@ are blanks."
   (interactive nil)
   (ocp-indent-region (point) (point)))
 
+(defun ocp-indent-buffer ()
+  (interactive nil)
+  (ocp-indent-region 0 (buffer-size)))
+
 ;;;###autoload
 (defun ocp-setup-indent ()
   (interactive nil)


### PR DESCRIPTION
The vim plugin contains OcpIndentBuffer, but the emacs mode does not contain a similar function, and it can be useful.
