### PR TITLE
Handle <keyword>%<attr> just like <keyword> in general

### DIFF
--- a/src/approx_lexer.mll
+++ b/src/approx_lexer.mll
@@ -299,12 +299,16 @@ rule parse_token = parse
            raise (Error(Keyword_as_label name, Location.curr lexbuf));
         *)
         OPTLABEL name }
-  | lowercase identchar *
+  | lowercase identchar * ( '%' identchar + ('.' identchar +) * ) ?
     { let s = Lexing.lexeme lexbuf in
       try
-        Hashtbl.find keyword_table s
+        let i = String.index_from s 1 '%' in
+        let kw = String.sub s 0 i in
+        try Hashtbl.find keyword_table kw
+        with Not_found -> rewind lexbuf (String.length s - i); LIDENT s
       with Not_found ->
-          LIDENT s }
+        try Hashtbl.find keyword_table s
+        with Not_found -> LIDENT s }
   | uppercase identchar *
     { UIDENT(Lexing.lexeme lexbuf) }      (* No capitalized keywords *)
   | int_literal

--- a/src/indentExtend.ml
+++ b/src/indentExtend.ml
@@ -37,15 +37,10 @@ open Approx_tokens
 let _ =
   register "lwt" ~keywords:[
     "for_lwt", FOR;
-    "for%lwt", FOR;
     "lwt", LET;
-    "let%lwt", LET;
     "match_lwt", MATCH;
-    "match%lwt", MATCH;
     "try_lwt", TRY;
-    "try%lwt", TRY;
     "while_lwt", WHILE;
-    "while%lwt", WHILE;
     "finally", WITH;  (* -- no equivalence for this one, this is a hack ! *)
   ] ();
   register "mll" ~keywords:[


### PR DESCRIPTION
this seems like a safe default even though extended attrs aren't yet fully
supported With this and the new syntax, the 'lwt' syntax extensions should
only be needed for 'finally' anymore

Closes #169