### PR TITLE
Consistency of the Vim plugin’s location and installation instructions.

### DIFF
--- a/ocp-indent.install
+++ b/ocp-indent.install
@@ -36,5 +36,5 @@ man: [
 ]
 share_root: [
   "tools/ocp-indent.el" {"emacs/site-lisp/ocp-indent.el"}
-  "tools/ocp-indent.vim" {"vim/syntax/ocp-indent.vim"}
+  "tools/ocp-indent.vim" {"vim/indent/ocaml.vim"}
 ]

--- a/opam
+++ b/opam
@@ -24,7 +24,8 @@ To use it from emacs, add the following to your .emacs:
   (require 'ocp-indent)
 
 To use it from Vim, add to your .vimrc:
-  execute \":source \" . \"%{share}%/vim/syntax/ocp-indent.vim\"
+  let g:opamshare=substitute(system('opam config var share'),'\n$','','''')
+  execute \"set rtp^=\" . g:opamshare . \"/vim\"
 "
   {success}
 ]


### PR DESCRIPTION
The Vim plugin was breaking the naming conventions of Vim: script files which provide indentation rules depending on the filetype must be named `indent/FILETYPE.vim`, with the `indent/` directory somewhere in Vim’s `'runtimepath'`. I simply renamed `OPAMSHARE/vim/syntax/ocp-indent.vim` to `OPAMSHARE/vim/indent/ocaml.vim`. I wonder if putting the `vim/` directory in `OPAMSHARE/ocp-indent/`, instead of the share root, would not be preferrable, but I am not familiar enough with OPAM packages for that.

Moreover, the installation instructions were wrong, because the plugin file needs to be sourced for each OCaml file being edited, not only once at Vim startup. This can be achieved with an autocommand, or simply by following the file naming convention above.
While we are, we can get the shared directory dynamically in the `vimrc` instead of hardcoding it, what can be useful because of OPAM switchs.
See also https://github.com/OCamlPro/ocp-indent/issues/151