### PR TITLE
remove usage of systemlist and improve caching in vim script

### DIFF
--- a/tools/ocp-indent.vim
+++ b/tools/ocp-indent.vim
@@ -37,15 +37,12 @@ let s:lnum = -1
 "let s:settings['max_indent'] = 2
 
 function! GetOcpIndent(lnum)
-  if s:buffer != bufnr('') || s:tick != b:changedtick || s:lnum > a:lnum
-    let cmdline = "ocp-indent --numeric --indent-empty --lines " . a:lnum . '-'
-    let s:indents = systemlist(cmdline, getline('1','$'))
+  if s:buffer != bufnr('') || s:tick != b:changedtick
+    let cmdline = "ocp-indent --numeric --indent-empty"
+    let s:indents = split(system(cmdline, join(getline('1','$'),"\n")), "\n")
     let s:buffer = bufnr('')
     let s:tick = b:changedtick
-  elseif s:lnum < a:lnum
-    call remove(s:indents, 0, a:lnum - s:lnum - 1)
   endif
-  let s:lnum = a:lnum
 
-  return s:indents[0]
+  return s:indents[a:lnum-1]
 endfunction


### PR DESCRIPTION
this pull request results from the discussion in issue#184

systemlist does not appear to be documented in vim scripts, this commit replaces the call with equivalent documented vim script functions call

The script now recomputes the indentation for the entire file only either the buffer has changed or when modifications have been made to the buffer. Rather than returning the first cell of the table and removing cells to make sure that it is the correct value, the script now return the value in the cell corresponding to the current line.