### PR TITLE
Upcoming cmdliner 0.9.8 compatibility.

### DIFF
--- a/src/indentConfig.mli
+++ b/src/indentConfig.mli
@@ -36,7 +36,8 @@ type t = {
 
 (** Documentation of the indentation options, in the Cmdliner 'Man.t' format *)
 val man:
-  [ `S of string | `P of string | `I of string * string | `Noblank ] list
+  [ `S of string | `P of string | `Pre of string | `I of string * string
+  | `Noblank ] list
 
 val default: t
 


### PR DESCRIPTION
Note that in practice it would be better to have `Cmdliner.Man.t` mentioned here, this would have avoided this incompatibility. It may be that you don't want to have the library dependent on `cmdliner` but then this could be put somewhere else. 