### PR TITLE
compile error and allow .fe.sexp at the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/buildable_targets.list
 tests/failing-output/.fe.sexp
 tests/failing/.fe.sexp
 tests/passing/.fe.sexp
+.fe.sexp

--- a/src/indentConfig.mli
+++ b/src/indentConfig.mli
@@ -36,7 +36,7 @@ type t = {
 
 (** Documentation of the indentation options, in the Cmdliner 'Man.t' format *)
 val man:
-  [ `S of string | `P of string | `Pre of string | `I of string * string
+  [ `S of string | `P of string | `I of string * string
   | `Noblank ] list
 
 val default: t


### PR DESCRIPTION
Hello.  This pull request contains two unrelated changes, I am happy to split it if relevant.  I am surprised by the compile error so I suspect I might just have missed a similar fix already existing somewhere.  I am just getting started on ocp-ident @ janestreet so feel free to give feed back about the way you'd like pull request to be presented / organized.
Best,
Mathieu.

1) gitignore allowing .fe.sexp at the root of the repo
2) Tried to build master today, and got the following error:

      File "src/indentArgs.ml", line 236, characters 62-65:
      Error: This expression has type
               [ `I of string * string
               | `Noblank
               | `P of string
               | `Pre of string
               | `S of string ] list
             but an expression was expected of type Cmdliner.Manpage.block list
             Type
               [ `I of string * string
               | `Noblank
               | `P of string
               | `Pre of string
               | `S of string ]
             is not compatible with type
               Cmdliner.Manpage.block =
                 [ `I of string * string | `Noblank | `P of string | `S of string ] 
             The second variant type does not allow tag(s) `Pre
