### PR TITLE
Git ignore [.fe.sexp] files in any directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,4 @@ src/.hgignore.in
 src/jbuild
 src/Makefile.extracted-from-jenga
 src/buildable_targets.list
-tests/failing-output/.fe.sexp
-tests/failing/.fe.sexp
-tests/passing/.fe.sexp
+**/.fe.sexp


### PR DESCRIPTION
(janestreet's code review metadata files).