### PR TITLE
Reintroduce 'guess_indent' in the new printer

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -1970,7 +1970,7 @@ let guess_indent t =
       (* closed expr and newline: we probably want a toplevel block *)
       let p = unwind_top p in
       Path.indent p + Path.pad p
-  | p when t.newlines >= 2 ->
+  | p when t.newlines > 2 ->
       (* After an empty line: we probably want a toplevel block *)
       let p = unwind_top p in
       Path.indent p + Path.pad p


### PR DESCRIPTION
This fixes unexpected behaviour when using 'tab' in $EDITOR.  The
specific case was unexpectedly dropped when intoducing explicit explicit
EOL in the lexer.