### PR TITLE
Change opam quick-config for vim and emacs to respect the actual switch

### DIFF
--- a/opam
+++ b/opam
@@ -24,11 +24,13 @@ post-messages: [
   "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:
 
 * for Emacs, add these lines to ~/.emacs:
-  (add-to-list 'load-path \"%{share}%/emacs/site-lisp\")
+  (setq opam-share (ignore-errors (car (process-lines \"opam\" \"config\" \"var\" \"share\"))))
+  (add-to-list 'load-path (concat opam-share \"/emacs/site-lisp\"))
   (require 'ocp-indent)
 
-* for Vim, add this line to ~/.vimrc:
-  set rtp^=\"%{share}%/ocp-indent/vim\"
+* for Vim, add these lines to ~/.vimrc:
+  let g:opamshare = substitute(system('opam config var share'),'\n$','','''')
+  set rtp^=\". g.opamshare . \"/ocp-indent/vim\"
 "
   {success & !user-setup:installed}
 ]


### PR DESCRIPTION
Unlike [*Merlin*](https://github.com/the-lambda-church/merlin), the quick-install commands given by opam have hardcoded paths.
This pull-request displays a slightly more portable example for the user, who isn't obliged to modify her configuration file at every ocaml switch update.
The commands are inspired by *Merlin*'s one, and were tested under vim 8.0.5 and emacs 25.1-1.