### PR TITLE
Fix indentation of local exceptions

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -1267,10 +1267,15 @@ let rec update_path config block stream tok =
   | SEMISEMI    -> append KUnknown L ~pad:0 (unwind_top block.path)
   | INCLUDE     -> append KInclude L (unwind_top block.path)
   | EXCEPTION   ->
-      let p = unwind (function KExpr _ -> false | _ -> true) block.path in
-      (match p with
-       | {kind=KWith KMatch|KBar KMatch}::_ -> append expr_atom L block.path
-       | _ -> append KException L (unwind_top block.path))
+      (match last_token block with
+       | Some LET ->
+           append KUnknown L block.path (* let exception *)
+       | _ ->
+           let p = unwind (function KExpr _ -> false | _ -> true) block.path in
+           (match p with
+            | {kind=KWith KMatch|KBar KMatch}::_ ->
+                append expr_atom L block.path
+            | _ -> append KException L (unwind_top block.path)))
   | BEGIN       -> open_paren KBegin block.path
   | OBJECT      -> append KObject L block.path
   | VAL         -> append KVal L (unwind_top block.path)

--- a/tests/passing/core-passing.ml
+++ b/tests/passing/core-passing.ml
@@ -171,3 +171,11 @@ let _ =
 
 type variant = [ `Jan | `Feb | `Mar | `Apr | `May | `Jun
                | `Jul | `Aug | `Sep | `Oct | `Nov | `Dec ]
+
+let _ =
+  let exception E in
+  ()
+
+let _ =
+  let exception E of string in
+  ()


### PR DESCRIPTION
The implementation follows the `let module` code

Fixes #234