### PR TITLE
Ignore ppx extension points on ;

### DIFF
--- a/src/approx_lexer.mll
+++ b/src/approx_lexer.mll
@@ -434,7 +434,7 @@ rule parse_token = parse
   | "::" { COLONCOLON }
   | ":=" { COLONEQUAL }
   | ":>" { COLONGREATER }
-  | ";"  { SEMI }
+  | ";" ( '%' identchar + ('.' identchar +) * ) ? { SEMI }
   | ";;" { SEMISEMI }
   | "<"  { LESS }
   | "<-" { LESSMINUS }

--- a/tests/passing/sequence.ml
+++ b/tests/passing/sequence.ml
@@ -66,3 +66,7 @@ let overflow_small =
   4611686018427387904 (* max_int (63) + 1 *)
 let overflow_big =
   46116860184273879030
+
+let ppx_sequence =
+  ();%ext
+  ()


### PR DESCRIPTION
Applied onto `rewind` instead of `master`

Should fix #232