### PR TITLE
remove CR -- causing internal diffs

### DIFF
--- a/tools/tuareg-indent
+++ b/tools/tuareg-indent
@@ -67,7 +67,7 @@ tuareg-indent() {
     ' 2>/dev/null || true
 }
 
-# CR-soon pszilagyi: This will whitespace-split individual arguments.
+# Note: This will whitespace-split individual arguments.
 args=
 while [ $# -gt 1 ]; do args="$args $1"; shift; done
 file=$1


### PR DESCRIPTION
This CR conflicts with an internal process that changes it to CR-someday periodically, causing a diff when I import the ocp-indent master.  Changed to a note.