### PR TITLE
emacs: pass an absolute file name to make-temp-name

### DIFF
--- a/tools/ocp-indent.el
+++ b/tools/ocp-indent.el
@@ -110,8 +110,7 @@ buffer."
   (let*
       ((start-line (line-number-at-pos start))
        (end-line (line-number-at-pos end))
-       (errfile (expand-file-name (make-temp-name "ocp-indent-error")
-                                  temporary-file-directory))
+       (errfile (make-temp-name (concat temporary-file-directory "ocp-indent-error")))
        (indents-str
         (with-output-to-string
           (ocp-indent--with-untabify


### PR DESCRIPTION
make-temp-name expects an absolute file name. Otherwise, it chooses
a name that is unique in the current directory, with no guarantee that the 
filename is unique in the temporary-file-directory.