### PR TITLE
Fix regression to legacy path introduced in #296

### DIFF
--- a/src/indentConfig.ml
+++ b/src/indentConfig.ml
@@ -414,7 +414,7 @@ let local_default ?(path=Sys.getcwd()) () =
           | x -> x ) / "ocp" / "ocp-indent.conf" in
       if Sys.file_exists xdg_path
       then load ~indent:conf xdg_path
-      else let legacy_path = (Sys.getenv "HOME") / ".ocp" / ".ocp-indent.conf" in
+      else let legacy_path = (Sys.getenv "HOME") / ".ocp" / "ocp-indent.conf" in
         if  Sys.file_exists legacy_path
         then load ~indent:conf legacy_path
         else conf, [], []


### PR DESCRIPTION
As noted by @bcc32 [here](https://github.com/OCamlPro/ocp-indent/pull/296#issuecomment-540112823), the legacy path was broken by my previous PR.

This fixes it.