### PR TITLE
Add an option 'match_tail_cascade=BOOL'

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -811,7 +811,16 @@ let rec update_path config block stream tok =
         | TRY -> KTry
         | _ -> assert false
       in
-      let p = fold_expr block.path in
+      let p =
+        if config.i_match_tail_cascade &&
+           (match block.path with
+            | {kind = KArrow (KMatch|KTry)} :: _ -> true
+            | _ -> false)
+        then
+          Path.maptop (fun n -> {n with pad = 0}) block.path
+        else
+          fold_expr block.path
+      in
       if starts_line then append k L p
       else
         let enforce_strict =

--- a/src/indentConfig.mli
+++ b/src/indentConfig.mli
@@ -34,6 +34,7 @@ type t = {
   i_strict_comments: bool;
   i_align_ops: bool;
   i_align_params: threechoices;
+  i_match_tail_cascade: bool;
 }
 
 (** Documentation of the indentation options, in the Cmdliner 'Manpage.block' format *)


### PR DESCRIPTION
Inspired by https://discuss.ocaml.org/t/tail-cascade-a-new-indentation-style-for-some-ocaml-constructs/4736