### PR TITLE
improve user-defined config file detection

### DIFF
--- a/doc/ocp-indent.md
+++ b/doc/ocp-indent.md
@@ -98,9 +98,15 @@ requiring them to change their settings in any way (except that, obviously, they
 need to use ocp-indent !).
 
 If a `.ocp-indent` file is found in the current directory or its ancestors, it
-overrides definitions from `$XDG_CONFIG_HOME/ocp/ocp-indent.conf`,
-`~/.ocp/ocp-indent.conf` and the built-in default. The command-line can of
-course still be used to override parameters defined in the files.
+overrides definitions from the user-defined configuration file (see below)
+and the built-in default. The command-line can of course still be used to 
+override parameters defined in the files.
+
+The user-defined configuration file depends on the platform you're using.
+On linux it is `$XDG_CONFIG_HOME/ocp-indent/config` with `$XDG_CONFIG_HOME`
+defaulting to `$HOME/.config/`. On macOS it is
+`$HOME/Library/Application Support/com.OCamlPro.ocp-indent/config`. On
+Windows it is `{FOLDERID_ApplicationData}/OCamlPro/ocp-indent/config`.
 
 Have a look at ocp-indent's own [`.ocp-indent`](.ocp-indent) file for an
 example.

--- a/ocp-indent.opam
+++ b/ocp-indent.opam
@@ -35,6 +35,7 @@ depends: [
   "cmdliner" {>= "1.0.0"}
   "ocamlfind"
   "base-bytes"
+  "directories" {>= "0.2"}
 ]
 post-messages: [
   "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:

--- a/src/dune
+++ b/src/dune
@@ -15,7 +15,7 @@
  (name ocp_indent_lib)
  (wrapped false)
  (public_name ocp-indent.lib)
- (libraries ocp-indent.utils)
+ (libraries ocp-indent.utils directories)
  (modules indentConfig indentBlock indentPrinter)
  (flags :standard -w -9 -warn-error -57)
 )

--- a/src/indentArgs.ml
+++ b/src/indentArgs.ml
@@ -212,9 +212,13 @@ let info =
         option, or as a configuration definition in one of the following, \
         searched in order: a file named `.ocp-indent' in the current directory \
         or its parents (which allows for per-project indentation settings), \
-        the file `\\$XDG_CONFIG_HOME/ocp/ocp-indent.conf', the file \
-        `\\$HOME/.ocp/ocp-indent.conf', or the environment variable \
-        \\$OCP_INDENT_CONFIG."
+        the user-defined configuration file (see below), or the environment \
+        variable \\$OCP_INDENT_CONFIG.";
+    `P "The user-defined configuration file depends on the platform you're \
+        using. On Linux it is `\\$XDG_CONFIG_HOME/ocp-indent/config' with \
+        `\\$XDG_CONFIG_HOME' defaulting to `\\$HOME/.config/'. On macOS it is \
+        `\\$HOME/Library/Application Support/com.OCamlPro.ocp-indent/config'. \
+        On Windows it is `{FOLDERID_ApplicationData}/OCamlPro/ocp-indent/config'"
   ] @
   IndentConfig.man
   @ [


### PR DESCRIPTION
Hi,

The idea behind this PR is to change the way the global user-defined configuration file path is chosen, to make it more standard and to follow the suitable conventions on all platforms. I used [directories](https://github.com/ocamlpro/directories).

With this PR, the path is computed as follow:

- on Linux, `$XDG_CONFIG_HOME/ocp-indent/config` with `$XDG_CONFIG_HOME` defaulting to `$HOME/.config/`
- on macOS, `$HOME/Library/Application Support/com.OCamlPro.ocp-indent/config`
- on Windows, `{FOLDERID_ApplicationData}/OCamlPro/ocp-indent/config` ; the path of `{FOLDERID_ApplicationData}` can be obtained only using [SHGetKnownFolderPath](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath)

`directories` has no dependency, except on Windows where it depends on `ctypes`, it works on all OCaml version from `4.07`, but I haven't tested older versions.