### PR TITLE
Treat the forward pipe (`|>`) as a monadic operator

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -439,7 +439,7 @@ let op_prio_align_indent config =
   in
   let is_monadop s =
     match String.sub s 0 (min 2 (String.length s)) with
-    | ">>" | ">|" | "@@" | "@>" -> true
+    | ">>" | ">|" | "@@" | "@>" | "|>" -> true
     | _ -> false
   in
   let is_monadop s =


### PR DESCRIPTION
Before this change the pipe was treated like standard binary operators:
```ocaml
let f x = x
          |> f
```

I *think* it makes more sense to treat it as a monadic:
```ocaml
let f x = x
  |> f
```