### PR TITLE
Consistent indentation of `fun` after `let`

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -1181,7 +1181,7 @@ let rec update_path config block stream tok =
             | KParen | KBegin | KBracket | KBrace | KBracketBar
             | KWith(KMatch|KTry) | KBar(KMatch|KTry) | KArrow(KMatch|KTry)
             | KFun
-            | KBody(KType|KExternal) | KColon
+            | KBody(KType|KExternal|KLet) | KColon
             | KStruct | KSig | KObject
             | KExtendedItem _ | KExtendedExpr _ -> true
             | _ -> false)
@@ -1191,10 +1191,11 @@ let rec update_path config block stream tok =
         | {kind=KFun} :: ({kind=KExpr i} as e) :: path when i = prio_flatop ->
             (* eg '>>= fun x ->': indent like the top of the expression *)
             {e with kind = KExpr 0} :: path
-        | {kind=KFun; line } :: {kind=KBody KLet; line=letline} :: _
+        | {kind=KFun; line } :: {kind=KBody(KLet|KLetIn); line=letline} :: _
           when next_offset tok stream = None
             && line = current_line && line <> letline
           ->
+            (* Special indentation of [fun] inside a [let]. *)
             append (KArrow KFun) L ~pad:0 (reset_line_indent config line path)
         | {kind=KFun; line; _ } :: _
           when next_offset tok stream = None

--- a/tests/passing/js-let.t
+++ b/tests/passing/js-let.t
@@ -87,3 +87,40 @@
             S.S.g s.S.s ~s
           in
           y)
+
+  $ cat > js-let.ml << "EOF"
+  > let indentation_after_fun =
+  >   fun foo ->
+  >   bar
+  > 
+  > let indentation_after_fun =
+  >   let f =
+  >     fun foo ->
+  >       bar
+  >   in
+  >   ()
+  > 
+  > module M = struct
+  >   let indentation_after_fun =
+  >     fun foo ->
+  >       bar
+  > end
+  > EOF
+
+  $ ocp-indent -c JaneStreet js-let.ml
+  let indentation_after_fun =
+    fun foo ->
+    bar
+  
+  let indentation_after_fun =
+    let f =
+      fun foo ->
+        bar
+    in
+    ()
+  
+  module M = struct
+    let indentation_after_fun =
+      fun foo ->
+      bar
+  end

--- a/tests/passing/js-let.t
+++ b/tests/passing/js-let.t
@@ -115,7 +115,7 @@
   let indentation_after_fun =
     let f =
       fun foo ->
-        bar
+      bar
     in
     ()
   


### PR DESCRIPTION
Apply the same indentation for:

    let f =
      fun x ->
      y

and:

    let _ =
      let f =
        fun x ->
        y
      in
      ()

The reason for this change is that a top-level-`let` can be interpreted
as a `LetIn`, for example:

    module M = struct
      let indentation_after_fun =
        fun foo ->
        bar
    end

We found this problem while working on OCamlformat for Janestreet.
An other solution to this problem would be to correctly interpret the `let`. What do you think ?