### PR TITLE
Fix detection of Let vs LetIn after a 'struct'

### DIFF
--- a/src/indentBlock.ml
+++ b/src/indentBlock.ml
@@ -937,11 +937,15 @@ let rec update_path config block stream tok =
       (* Two ways to detect let vs letin ;
          both seem to work, but need to check which one
          is the most robust (for example w.r.t. unfinished expressions) *)
-      (* - it's a top Let if it is after a closed expression *)
+      (* it's a top Let if it is:
+         - after a closed expression
+         - inside a [struct]
+         - after [type = |]
+      *)
       (match block.path with
        | {kind=KExpr i}::p when i = prio_max ->
            append KLet L (unwind_top p)
-       | [] | {kind=KCodeInComment}::_ | {kind=KBar KType}::_ as p->
+       | [] | {kind=KCodeInComment | KBar KType | KStruct}::_ as p->
            append KLet L (unwind_top p)
        | _ ->
            append KLetIn L (fold_expr block.path))

--- a/tests/passing/module.t
+++ b/tests/passing/module.t
@@ -60,6 +60,14 @@
   >                   with type t1 = t1'
   >                    and type t2 = t2')
   > 
+  > (* Detection of [Let] vs [LetIn] inside a [struct]. *)
+  > module M = struct
+  >   let indentation_after_fun =
+  >     fun foo ->
+  >       bar
+  > end
+  > 
+  > (* Unfinished [struct] *)
   > module Store (K: API.KEY) (V: API.VALUE) :
   >   API.STORE with module K = K
   >              and module V = V =
@@ -129,6 +137,14 @@
                     with type t1 = t1'
                      and type t2 = t2')
   
+  (* Detection of [Let] vs [LetIn] inside a [struct]. *)
+  module M = struct
+    let indentation_after_fun =
+      fun foo ->
+        bar
+  end
+  
+  (* Unfinished [struct] *)
   module Store (K: API.KEY) (V: API.VALUE) :
     API.STORE with module K = K
                and module V = V =

--- a/tests/passing/module.t
+++ b/tests/passing/module.t
@@ -141,7 +141,7 @@
   module M = struct
     let indentation_after_fun =
       fun foo ->
-        bar
+      bar
   end
   
   (* Unfinished [struct] *)


### PR DESCRIPTION
An indented `let` inside a `struct ... end` was incorrectly interpreted as a `LetIn`.

Same motivation as in https://github.com/OCamlPro/ocp-indent/pull/323. The indentation of `fun` is different inside a `Let` and a `LetIn`.