### PR TITLE
Remove unnecessary 'bytes' dependency

### DIFF
--- a/ocp-indent.opam
+++ b/ocp-indent.opam
@@ -34,7 +34,6 @@ depends: [
   "dune" {>= "1.0"}
   "cmdliner" {>= "1.0.0"}
   "ocamlfind"
-  "base-bytes"
 ]
 post-messages: [
   "This package requires additional configuration for use in editors. Install package 'user-setup', or manually:

--- a/src/dune
+++ b/src/dune
@@ -23,7 +23,7 @@
  (name ocp_indent_utils)
  (public_name ocp-indent.utils)
  (wrapped false)
- (libraries bytes ocp-indent.lexer)
+ (libraries ocp-indent.lexer)
  (modules compat pos util nstream)
 )
 (library


### PR DESCRIPTION
`ocp-indent` is built with Dune, which is only supported on OCaml version >= 4.02, which is the version when `bytes` was introduced.