### PR TITLE
Fix "Missing ‘lexical-binding’ cookie" warning in Emacs

### DIFF
--- a/tools/ocp-indent.el
+++ b/tools/ocp-indent.el
@@ -1,4 +1,4 @@
-;;; ocp-indent.el --- automatic indentation with ocp-indent
+;;; ocp-indent.el --- automatic indentation with ocp-indent -*- lexical-binding: t -*-
 ;;
 ;; Copyright 2012-2013 OCamlPro
 


### PR DESCRIPTION
What it says on the tin.

![image](https://github.com/user-attachments/assets/9559aefb-23d8-40e3-946f-f691d8f502c3)
