### PR TITLE
Fix typos in docs, comments and copyright headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 * fixes some cases of comments
 * supports new cases of ppx
 * fixed cases of unstable indentation within records
-* supports local excemtions
+* supports local exceptions
 * fixed handling of polymorphic methods
 * uses cmdliner 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ As `ocp-indent` is a command-line tool, you can easily integrate it with other e
 ocp-indent <src-file> > <dst-file>
 ```
 
-You can also tell it to indent only a subsets of lines, and to output only the indentation level:
+You can also tell it to indent only subsets of lines, and to output only the indentation level:
 
 ```bash
 ocp-indent <src-file> --lines <l1>-<l2> --numeric
@@ -102,7 +102,7 @@ example.
 
 ### In-file configuration
 There is no built-in support for in-file configuration directives. Yet, some
-editors already provide that features, and with emacs, starting your file with a
+editors already provide these features, and with emacs, starting your file with a
 line like:
 
 ```
@@ -154,7 +154,7 @@ adding the following dune rules to the `dune` file:
 ## How does it compare to tuareg ?
 
 We've run some benchmarks on real code-bases and the result is quite
-conclusive. Keep in mind than most of existing source files are
+conclusive. Keep in mind that most of existing source files are
 either indented manually or following tuareg standards. You can
 see the results [here](http://htmlpreview.github.com/?https://github.com/AltGr/ocp-indent-tests/blob/master/status.html).
 
@@ -186,7 +186,7 @@ The tests are organized as follows:
 * `tests/test.sh --[git-]update` updates the current reference state.
 * See `tests/test.sh --help` for more
 
-Please make sure tu run `make && tests/test.sh --git-update` before any commit,
+Please make sure to run `make && tests/test.sh --git-update` before any commit,
 so that the repo always reflects the state of the program.
 
 

--- a/doc/ocp-indent.md
+++ b/doc/ocp-indent.md
@@ -74,7 +74,7 @@ As `ocp-indent` is a command-line tool, you can easily integrate it with other e
 ocp-indent <src-file> > <dst-file>
 ```
 
-You can also tell it to indent only a subsets of lines, and to output only the indentation level:
+You can also tell it to indent only subsets of lines, and to output only the indentation level:
 
 ```bash
 ocp-indent <src-file> --lines <l1>-<l2> --numeric
@@ -107,7 +107,7 @@ example.
 
 ### In-file configuration
 There is no built-in support for in-file configuration directives. Yet, some
-editors already provide that features, and with emacs, starting your file with a
+editors already provide these features, and with emacs, starting your file with a
 line like:
 
 ```
@@ -121,7 +121,7 @@ file.
 ## How does it compare to tuareg ?
 
 We've run some benchmarks on real code-bases and the result is quite
-conclusive. Keep in mind than most of existing source files are
+conclusive. Keep in mind that most of existing source files are
 either indented manually or following tuareg standards. You can
 see the results [here](http://htmlpreview.github.com/?https://github.com/AltGr/ocp-indent-tests/blob/master/status.html).
 
@@ -153,5 +153,5 @@ The tests are organized as follows:
 * `tests/test.sh --[git-]update` updates the current reference state.
 * See `tests/test.sh --help` for more
 
-Please make sure tu run `make && tests/test.sh --git-update` before any commit,
+Please make sure to run `make && tests/test.sh --git-update` before any commit,
 so that the repo always reflects the state of the program.

--- a/src/ocp-indent-dynlink/indentLoader.ml
+++ b/src/ocp-indent-dynlink/indentLoader.ml
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-dynlink/indentLoader.mli
+++ b/src/ocp-indent-dynlink/indentLoader.mli
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lexer/indentExtend.ml
+++ b/src/ocp-indent-lexer/indentExtend.ml
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lexer/indentExtend.mli
+++ b/src/ocp-indent-lexer/indentExtend.mli
@@ -1,6 +1,6 @@
 (**************************************************************************)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lib/indentBlock.ml
+++ b/src/ocp-indent-lib/indentBlock.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012,2015 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lib/indentBlock.mli
+++ b/src/ocp-indent-lib/indentBlock.mli
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012,2013 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lib/indentConfig.ml
+++ b/src/ocp-indent-lib/indentConfig.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2013 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lib/indentConfig.mli
+++ b/src/ocp-indent-lib/indentConfig.mli
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*  Copyright 2013 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lib/indentPrinter.ml
+++ b/src/ocp-indent-lib/indentPrinter.ml
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*  Copyright 2012,2013 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-lib/indentPrinter.mli
+++ b/src/ocp-indent-lib/indentPrinter.mli
@@ -2,7 +2,7 @@
 (*                                                                        *)
 (*  Copyright 2013 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-utils/nstream.ml
+++ b/src/ocp-indent-utils/nstream.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012-2013 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-utils/nstream.mli
+++ b/src/ocp-indent-utils/nstream.mli
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012-2013 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-utils/pos.ml
+++ b/src/ocp-indent-utils/pos.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-utils/pos.mli
+++ b/src/ocp-indent-utils/pos.mli
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent-utils/util.ml
+++ b/src/ocp-indent-utils/util.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012,2013 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent/indentArgs.ml
+++ b/src/ocp-indent/indentArgs.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2013 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent/indentArgs.mli
+++ b/src/ocp-indent/indentArgs.mli
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2013 OCamlPro                                               *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/src/ocp-indent/indentMain.ml
+++ b/src/ocp-indent/indentMain.ml
@@ -3,7 +3,7 @@
 (*  Copyright 2011 Jun Furuse                                             *)
 (*  Copyright 2012,2013 OCamlPro                                          *)
 (*                                                                        *)
-(*  All rights reserved.This file is distributed under the terms of the   *)
+(*  All rights reserved. This file is distributed under the terms of the   *)
 (*  GNU Lesser General Public License version 2.1 with linking            *)
 (*  exception.                                                            *)
 (*                                                                        *)

--- a/tools/ocp-indent.el
+++ b/tools/ocp-indent.el
@@ -5,7 +5,7 @@
 ;; Keywords: ocaml languages
 ;; URL: http://www.typerex.org/ocp-indent.html
 
-;; All rights reserved.This file is distributed under the terms of the
+;; All rights reserved. This file is distributed under the terms of the
 ;; GNU Lesser General Public License version 2.1 with linking
 ;; exception.
 

--- a/tools/ocp-indent.el
+++ b/tools/ocp-indent.el
@@ -21,7 +21,7 @@
 ;; ocp-indent is a simple tool and library to indent OCaml code.
 
 ;; Installation:
-;; You need ocp-indent installed on you system to work.
+;; You need ocp-indent installed on your system to work.
 
 ;; Usage:
 ;; Eval this file to automatically use ocp-indent on caml/tuareg buffers.

--- a/tools/tuareg-indent
+++ b/tools/tuareg-indent
@@ -2,7 +2,7 @@
 #
 # Copyright 2012-2013 OCamlPro
 #
-# All rights reserved.This file is distributed under the terms of the
+# All rights reserved. This file is distributed under the terms of the
 # GNU Lesser General Public License version 2.1 with linking
 # exception.
 #


### PR DESCRIPTION
Fix various typos and grammar mistakes throughout the codebase:

- "a subsets" → "subsets"
- "provide that features" → "provide these features"
- "Keep in mind than" → "Keep in mind that"
- "tu run" → "to run"
- "excemtions" → "exceptions" (CHANGELOG)
- "you system" → "your system" (ocp-indent.el)
- "reserved.This" → "reserved. This" (copyright headers, 20 files)