### PR TITLE
Add explicit support for effect syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## unreleased
 
 + Bump OCaml lower bound to 4.11 (#343, @NathanReb)
++ Add explicit support for effect syntax (#342, @NathanReb)
 
 ## 1.9.0
 

--- a/src/ocp-indent-lib/indentBlock.ml
+++ b/src/ocp-indent-lib/indentBlock.ml
@@ -72,6 +72,7 @@ module Node = struct
     | KWhen
     | KExternal
     | KCodeInComment
+    | KEffect
     | KExtendedExpr of string list * extension_kind
     | KExtendedItem of string list * extension_kind
     | KAttrId of string list * bool
@@ -143,6 +144,7 @@ module Node = struct
     | KWhen -> "KWhen"
     | KExternal -> "KExternal"
     | KCodeInComment -> "KCodeInComment"
+    | KEffect -> "KEffect"
     | KExtendedExpr (name, kind) ->
         Printf.sprintf "KExtendedExpr(%s,%s)"
           (String.concat "." (List.rev name))
@@ -802,6 +804,25 @@ let rec update_path config block stream tok =
             | {kind=KWith KMatch|KBar KMatch}::_ ->
                 append expr_atom L block.path
             | _ -> append KException L (unwind_top block.path)))
+  | LIDENT "effect" ->
+      (* We need to determine whether we're post 5.3 and this is the effect
+         keyword or we're pre 5.3 and it's a regular identifier.
+         The effect syntax is fairly restrictive but it is allowed to wrap an
+         effect pattern in parens. This should be the only thing separating
+         the effect keyword from a [with] or [|]. *)
+      let p = unwind (function KParen -> false | _ -> true) block.path in
+      (match p with
+       | {kind=KWith (KTry|KMatch)|KBar (KTry|KMatch); _}::_ ->
+           (* Modulo the parens, the effect keyword can only appear next to
+              [with] or [|]. *)
+           (match next_token stream with
+            | Some (LIDENT _ | UIDENT _ | UNDERSCORE) ->
+                (* The effect keyword is directly followed by a pattern, no
+                   parens are allowed, which makes it easy to distinguish from
+                   a var pattern named [effect]. *)
+                append KEffect L block.path
+            | _ -> atom block.path)
+       | _ -> atom block.path)
   | BEGIN       -> open_paren KBegin block.path
   | OBJECT      -> append KObject L block.path
   | VAL         -> append KVal L (unwind_top block.path)

--- a/tests/passing/effect_syntax.t
+++ b/tests/passing/effect_syntax.t
@@ -33,8 +33,8 @@ Here we test that the effect syntax is correctly handled in all cases
     |
       effect
         E
-      ,
-      k
+        ,
+        k
       ->
         continue k ()
 
@@ -61,16 +61,16 @@ Here we test that the effect syntax is correctly handled in all cases
   let x =
     match y with
     | effect
-        E
+      E
       ,
       k
       -> continue k ()
     | effect E
-      ,
-      k
+             ,
+             k
       -> continue k ()
     | effect E,
-      k
+             k
       -> continue k ()
 
 4. An effect pattern in a `try _ with`
@@ -93,8 +93,8 @@ Here we test that the effect syntax is correctly handled in all cases
     |
       effect
         E
-      ,
-      k
+        ,
+        k
       ->
         continue k ()
 
@@ -120,8 +120,8 @@ Here we test that the effect syntax is correctly handled in all cases
     |
       effect
         E
-      ,
-      k
+        ,
+        k
       when
         condition
       ->
@@ -146,9 +146,9 @@ Here we test that the effect syntax is correctly handled in all cases
     match y with
     |
       (effect
-         E
-       ,
-       k)
+        E
+        ,
+        k)
       ->
         continue k ()
 
@@ -169,7 +169,7 @@ Here we test that the effect syntax is correctly handled in all cases
     |
       effect
         E
-      ,
+        ,
 
 9. pre 5.3 code can still use `effect` as a pattern variable
 

--- a/tests/passing/effect_syntax.t
+++ b/tests/passing/effect_syntax.t
@@ -1,0 +1,209 @@
+Here we test that the effect syntax is correctly handled in all cases
+
+1. A basic use, no special indentation required:
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  >  | effect E, k -> continue k ()
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    | effect E, k -> continue k ()
+
+2. one element per line to check everything is correctly indented:
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  > |
+  > effect
+  > E
+  > ,
+  > k
+  > ->
+  > continue k ()
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    |
+      effect
+        E
+      ,
+      k
+      ->
+        continue k ()
+
+3. check with various line break positions:
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  > | effect
+  > E
+  > ,
+  > k
+  > -> continue k ()
+  > | effect E
+  > ,
+  > k
+  > -> continue k ()
+  > | effect E,
+  > k
+  > -> continue k ()
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    | effect
+        E
+      ,
+      k
+      -> continue k ()
+    | effect E
+      ,
+      k
+      -> continue k ()
+    | effect E,
+      k
+      -> continue k ()
+
+4. An effect pattern in a `try _ with`
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  try y () with
+  > |
+  > effect
+  > E
+  > ,
+  > k
+  > ->
+  > continue k ()
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    try y () with
+    |
+      effect
+        E
+      ,
+      k
+      ->
+        continue k ()
+
+5. An effect pattern with a guard
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  > |
+  > effect
+  > E
+  > ,
+  > k
+  > when
+  > condition
+  > ->
+  > continue k ()
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    |
+      effect
+        E
+      ,
+      k
+      when
+        condition
+      ->
+        continue k ()
+
+7. An effect pattern can be wrapped in parens, this should be handled correctly
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  > |
+  > (effect
+  > E
+  > ,
+  > k)
+  > ->
+  > continue k ()
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    |
+      (effect
+         E
+       ,
+       k)
+      ->
+        continue k ()
+
+8. incomplete effect pattern should be correctly indented
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  > |
+  > effect
+  > E
+  > ,
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    |
+      effect
+        E
+      ,
+
+9. pre 5.3 code can still use `effect` as a pattern variable
+
+  $ cat > test.ml << EOF
+  > let x =
+  >  match y with
+  > |
+  > (effect,
+  > z)
+  > -> do_something_effect z
+  > |
+  > effect,
+  > z
+  > ->
+  > do_something effect z
+  > |
+  > z,
+  > effect
+  > -> do_something effect z
+  > EOF
+
+  $ ocp-indent test.ml
+  let x =
+    match y with
+    |
+      (effect,
+       z)
+      -> do_something_effect z
+    |
+      effect,
+      z
+      ->
+        do_something effect z
+    |
+      z,
+      effect
+      -> do_something effect z


### PR DESCRIPTION
The default handling of the effect syntax wasn't great, they were indented as if they were a pair `effect _` and `k`.

This PR adds explicit support, making it so that the effect and the continuation are both treated as "arguments" to the `effect` keyword.

ocp-indent should remain compatible with pre 5.3 code that uses `effect` as an identifier. The syntax is unambiguous and with a little bit of context it is very easy to determine whether we're looking at the keyword in the effect syntax context or a regular identifier.