### PR TITLE
Add support for starred style comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 + Remove support for legacy camlp4 extensions that was causing misidentation of
   code using some predefined identifiers (`TEST`, `BENCH`, `IFDEF`)
   (#345, @NathanReb)
++ Add support for starred style comments (#347, @NathanReb)
 
 ## 1.9.0
 

--- a/src/ocp-indent-lib/indentPrinter.ml
+++ b/src/ocp-indent-lib/indentPrinter.ml
@@ -108,11 +108,54 @@ let print_indent output line blank ?(kind=Normal) block usr =
     | Extended pr -> pr block (Whitespace blank) usr
   )
 
+(* Tells whether the given comment has each line starting with a ['*'] and
+   whether they will all be aligned once properly indented.
+   Used to determine how to indent a lone comment close on its own line, i.e.
+   whether it should be indent as the comment open or as the comment open + 1.
+*)
+let star_aligned_comment ~strict_comments ~orig_start_column tok _first_line
+    next_lines =
+  match tok.token, next_lines with
+  | COMMENT, _::_ ->
+      let without_closing_line =
+        match List.rev next_lines with
+        | hd::tl ->
+            if is_prefix "*)" (String.trim hd) then List.rev tl
+            else next_lines
+        | _ -> assert false
+      in
+      (match without_closing_line with
+       | [] ->
+           (* The comment contains only one line + a line with a lone comment
+              close. That's not enough to determine the user want star aligned
+              comments, we default to regular indentation. *)
+           false
+       | _ ->
+           List.for_all
+             (fun line ->
+                let trimmed = String.trim line in
+                if strict_comments then
+                  (* Starts with a ['*'], strict_comments will take care
+                     of aligning leading stars. *)
+                  is_prefix "*" trimmed
+                else
+                  (* Starts with a ['*'] and is already aligned with
+                     the star from the comment open. *)
+                  is_prefix "*)" trimmed ||
+                  let line_len = String.length line in
+                  let trimmed_len = String.length trimmed in
+                  let line_indent = line_len - trimmed_len in
+                  (is_prefix "*" trimmed &&
+                   Int.equal line_indent (orig_start_column + 1)))
+             without_closing_line)
+  | _ -> false
+
 let print_token output block tok usr =
   let orig_start_column = IndentBlock.original_column block in
   let start_column = IndentBlock.offset block in
   (* Handle multi-line tokens (strings, comments) *)
-  let rec print_extra_lines line pad last ?(item_cont=false) lines usr =
+  let rec print_extra_lines line pad last ?(star_aligned_comment=false)
+      ?(item_cont=false) lines usr =
     match lines with
     | [] -> usr
     | text::next_lines ->
@@ -121,11 +164,11 @@ let print_token output block tok usr =
           usr
           |> print_indent output line "" block
           |> pr_string output block text
-          |> print_extra_lines (line+1) pad text next_lines
+          |> print_extra_lines ~star_aligned_comment (line+1) pad text next_lines
         else if String.trim text = "" && tok.token <> OCAMLDOC_VERB then
           usr
           |> print_indent output line "" ~kind:Empty block
-          |> print_extra_lines (line+1) pad text next_lines
+          |> print_extra_lines ~star_aligned_comment (line+1) pad text next_lines
         else
           let orig_line_indent = count_leading_spaces text in
           let orig_offset = orig_line_indent - orig_start_column in
@@ -157,7 +200,11 @@ let print_token output block tok usr =
                     if output.config.IndentConfig.i_strict_comments || is_item
                     then n else max orig_offset n
                   in
-                  let n = if next_lines = [] && text = "*)" then 0 else n in
+                  let n =
+                    if next_lines = [] && text = "*)" then
+                      (if star_aligned_comment then 1 else 0)
+                    else n
+                  in
                   start_column + n, item_cont
               | QUOTATION opening ->
                   if is_prefix "{" opening then orig_line_indent, item_cont
@@ -171,7 +218,8 @@ let print_token output block tok usr =
           usr
           |> print_indent output line "" ~kind:(Fixed indent_value) block
           |> pr_string output block text
-          |> print_extra_lines (line+1) pad ~item_cont text next_lines
+          |> print_extra_lines ~star_aligned_comment (line+1) pad ~item_cont
+            text next_lines
   in
   let line = Region.start_line tok.region in
   let text, next_lines =
@@ -179,6 +227,10 @@ let print_token output block tok usr =
     else match string_split '\n' (Lazy.force tok.substr) with
       | [] -> assert false
       | hd::tl -> hd,tl
+  in
+  let strict_comments = output.config.IndentConfig.i_strict_comments in
+  let star_aligned_comment =
+    star_aligned_comment ~strict_comments ~orig_start_column tok text next_lines
   in
   let pad =
     if next_lines = [] then None
@@ -207,7 +259,7 @@ let print_token output block tok usr =
   in
   usr
   |> pr_string output block text
-  |> print_extra_lines (line+1) pad text next_lines
+  |> print_extra_lines ~star_aligned_comment (line+1) pad text next_lines
 
 (* [block] is the current indentation block
    [stream] is the token stream *)

--- a/tests/passing/star-aligned-comments.t
+++ b/tests/passing/star-aligned-comments.t
@@ -1,0 +1,140 @@
+The opening and closing comments marker should have their `*` aligned when the
+closing marker is on its own line and:
+- strict_comments=true, all comment lines start with a `*`
+- strict_comments=false, all comment lines start with a `*` aligned with the
+
+In the following example, the closing marker should be regularly aligned with
+the opening marker, not star-aligned, regargless of strict_comments:
+
+  $ cat > test.ml << EOF
+  > (* hello
+  >        world
+  >         *)
+  > EOF
+
+  $ ocp-indent --config strict_comments=false test.ml
+  (* hello
+         world
+  *)
+
+  $ ocp-indent --config strict_comments=true test.ml
+  (* hello
+     world
+  *)
+
+In the following example, the closing marker should be star aligned, regardless
+of strict_comments:
+
+  $ cat > test.ml << EOF
+  > (* hello
+  >  * world
+  >         *)
+  > EOF
+
+  $ ocp-indent --config strict_comments=false test.ml
+  (* hello
+   * world
+  *)
+
+  $ ocp-indent --config strict_comments=true test.ml
+  (* hello
+   * world
+  *)
+
+In the following example, the closing marker should be star aligned only
+with strict_comments=true:
+
+  $ cat > test.ml << EOF
+  > (* hello
+  >       * world
+  >         *)
+  > EOF
+
+  $ ocp-indent --config strict_comments=false test.ml
+  (* hello
+        * world
+  *)
+
+  $ ocp-indent --config strict_comments=true test.ml
+  (* hello
+   * world
+  *)
+
+In ambiguous cases such as the following, we should default to classic alignment:
+
+  $ cat > test.ml << EOF
+  > (* hello world
+  >     *)
+  > EOF
+
+  $ ocp-indent --config strict_comments=false test.ml
+  (* hello world
+  *)
+
+  $ ocp-indent --config strict_comments=true test.ml
+  (* hello world
+  *)
+
+The star-alignment detection should work even when the whole is not correctly
+indented, i.e. in the following example, the first comment should always be
+star aligned, the second should be star aligned when strict_comments=true:
+
+  $ cat > test.ml << EOF
+  >      (* hello
+  >       * world
+  >           *)
+  > 
+  >       (* hello
+  >            * world
+  >                *)
+  > EOF
+
+  $ ocp-indent --config strict_comments=false test.ml
+  (* hello
+   * world
+  *)
+  
+  (* hello
+       * world
+  *)
+
+  $ ocp-indent --config strict_comments=true test.ml
+  (* hello
+   * world
+  *)
+  
+  (* hello
+   * world
+  *)
+
+Doc comments are handled as strict_comments handles them, that is they are
+considered star aligned if the leading star on each line is aligned with the
+first star of '(**':
+
+  $ cat > test.ml << EOF
+  > (** hello
+  >      * world
+  >         *)
+  > 
+  > (** hello
+  >  * world
+  >      *)
+  > EOF
+
+  $ ocp-indent --config strict_comments=false test.ml
+  (** hello
+       * world
+  *)
+  
+  (** hello
+   * world
+  *)
+
+  $ ocp-indent --config strict_comments=true test.ml
+  (** hello
+   * world
+  *)
+  
+  (** hello
+   * world
+  *)

--- a/tests/passing/star-aligned-comments.t
+++ b/tests/passing/star-aligned-comments.t
@@ -34,12 +34,12 @@ of strict_comments:
   $ ocp-indent --config strict_comments=false test.ml
   (* hello
    * world
-  *)
+   *)
 
   $ ocp-indent --config strict_comments=true test.ml
   (* hello
    * world
-  *)
+   *)
 
 In the following example, the closing marker should be star aligned only
 with strict_comments=true:
@@ -58,7 +58,7 @@ with strict_comments=true:
   $ ocp-indent --config strict_comments=true test.ml
   (* hello
    * world
-  *)
+   *)
 
 In ambiguous cases such as the following, we should default to classic alignment:
 
@@ -92,7 +92,7 @@ star aligned, the second should be star aligned when strict_comments=true:
   $ ocp-indent --config strict_comments=false test.ml
   (* hello
    * world
-  *)
+   *)
   
   (* hello
        * world
@@ -101,11 +101,11 @@ star aligned, the second should be star aligned when strict_comments=true:
   $ ocp-indent --config strict_comments=true test.ml
   (* hello
    * world
-  *)
+   *)
   
   (* hello
    * world
-  *)
+   *)
 
 Doc comments are handled as strict_comments handles them, that is they are
 considered star aligned if the leading star on each line is aligned with the
@@ -128,13 +128,13 @@ first star of '(**':
   
   (** hello
    * world
-  *)
+   *)
 
   $ ocp-indent --config strict_comments=true test.ml
   (** hello
    * world
-  *)
+   *)
   
   (** hello
    * world
-  *)
+   *)


### PR DESCRIPTION
Fixes #312

This adds support for indenting comments in the following style:
```ocaml
(* some
 * star aligned
 * comment
 *)
```

This is enabled when all lines of the comment start with a `*` and `strict_comments=true`. It will then align all stars including the one from the comment closing `*)` when it lives on its own line. The comment close used to always be indented at the same level as the comment open, as reported in #312.
The comment close will also be correctly aligned when `strict_comments=false` if all comment lines start with a `*` and are already correctly aligned. Note that without `strict_comments` comment lines are never indented and simply left untouched which is why we implemented it this way.