### PR TITLE
Add explicit support for labeled tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   code using some predefined identifiers (`TEST`, `BENCH`, `IFDEF`)
   (#345, @NathanReb)
 + Add support for starred style comments (#347, @NathanReb)
++ Add explicit support for labeled tuples syntax (#349, @NathanReb)
 
 ## 1.9.0
 

--- a/src/ocp-indent-lib/indentBlock.ml
+++ b/src/ocp-indent-lib/indentBlock.ml
@@ -371,11 +371,12 @@ let last_token t =
    rare, corner case we could end up looking up quite far ahead.
 *)
 let in_arrow_type stream =
+  let max_distance = 30 in
   let rec aux ~distance ~depth stream =
     match next_token_full stream with
     | None -> false
     (* distance acts as a failsafe *)
-    | Some _ when distance >= 100 -> false
+    | Some _ when distance >= max_distance -> false
     | Some (tok, stream) ->
         let distance = distance + 1 in
         match tok, depth with

--- a/src/ocp-indent-lib/indentBlock.ml
+++ b/src/ocp-indent-lib/indentBlock.ml
@@ -90,6 +90,9 @@ module Node = struct
   let expr_atom = KExpr prio_max
   let expr_apply = KExpr 140
   let prio_lbracketat = 30
+  (* Special colon prio used to correctly indent labeled tuples *)
+  let prio_star = 100
+  let prio_colon_tuple = prio_star
   (* Special operators that should break arrow indentation have this prio
      (eg monad operators, >>=) *)
   let prio_flatop = 59
@@ -362,6 +365,54 @@ let last_token t =
   in
   aux t.last
 
+(* Returns whether there's an arrow coming up. Used to correctly
+   indent labeled tuples VS labeled arguments.
+   We stop looking after a predefined distance as in some, presumably extremely
+   rare, corner case we could end up looking up quite far ahead.
+*)
+let in_arrow_type stream =
+  let rec aux ~distance ~depth stream =
+    match next_token_full stream with
+    | None -> false
+    (* distance acts as a failsafe *)
+    | Some _ when distance >= 100 -> false
+    | Some (tok, stream) ->
+        let distance = distance + 1 in
+        match tok, depth with
+        | {token = EOF}, _ -> false
+        | {token = MINUSGREATER; _}, 0 -> true
+        | {token =
+             (* End of phrase *)
+             ( SEMISEMI
+             (* Begining of next item *)
+             | LBRACKETATAT | LBRACKETPERCENTPERCENT | LINE_DIRECTIVE | MATCH
+             | METHOD | CLASS | AND | BEGIN | MODULE | VAL | LET | DO | WHILE
+             | FOR
+             (* End of current core type *)
+             | EQUAL | RPAREN | RBRACKET | RBRACE | GREATER | SEMI | COMMA | BAR
+             | IN | DONE | WHEN | ELSE | THEN
+             )
+          ; _}, 0 ->
+            false
+        | {token =
+             ( LBRACKET | LBRACKETLESS | LBRACKETGREATER
+             | LBRACKETAT | LBRACKETPERCENT
+             | LPAREN
+             | LESS
+             )
+          ; _}, depth ->
+            aux ~distance ~depth:(depth + 1) stream
+        | {token = RPAREN | GREATER | RBRACKET; _}, _ ->
+            (* Only reached when [depth > 0]. Does not track which is opened,
+               undefined behaviour on incorrect code. *)
+            aux ~distance ~depth:(depth - 1) stream
+        | _ -> aux ~distance ~depth stream
+  in
+  aux
+    ~distance:0
+    ~depth:0
+    stream
+
 (* a more efficient way to do this would be to store a
    "context-type" in the stack *)
 let rec is_inside_type path =
@@ -478,7 +529,7 @@ let op_prio_align_indent config =
   | LBRACKETAT -> prio_lbracketat,align,indent
   | COLONCOLON -> 80,align,indent
   | INFIXOP2 _ | PLUSDOT | PLUS | MINUSDOT | MINUS -> 90,align,indent
-  | INFIXOP3 _ | STAR -> 100,align,indent
+  | INFIXOP3 _ | STAR -> prio_star,align,indent
   | INFIXOP4 _ -> 110,align,indent
   (* apply: 140 *)
   | AS -> prio_apply,L,0
@@ -543,6 +594,7 @@ let ext_kind = function
   | LBRACKETPERCENT | LBRACKETPERCENTPERCENT -> ExtNode
   | LBRACKETAT | LBRACKETATAT | LBRACKETATATAT -> Attr
   | _ -> invalid_arg "ext_kind"
+
 
 (* Take a block, a token stream and a token.
    Return the new block stack. *)
@@ -788,6 +840,34 @@ let rec update_path config block stream tok =
   let block = match block.path with
     | {kind=KComment _|KVerbatim _|KUnknown}::path -> {block with path}
     | _ -> block
+  in
+  (* Handles labels [:] in type expressions, trying to determine whether
+       the label belongs to a tuple or an upcoming arrow type. *)
+  let tuple_or_argument_label () =
+    let after_star =
+      match block.path with
+      | {kind = KExpr 200; _} :: {kind = KExpr 100; _} :: _ ->
+          (* Our [:] is after `* <label>` *)
+          true
+      | _ -> false
+    in
+    (* After a star, we know the label belongs to the tuple, no need for
+       the annoying and costly look ahead, *)
+    let in_arrow = not after_star && in_arrow_type stream in
+    (* If we're not in an arrow, we align with the beginning of the tuple
+       type *)
+    let unwind_prio = if in_arrow then prio_arrow else prio_star in
+    let target_prio = if in_arrow then prio_colon else prio_colon_tuple in
+    (match unwind_while (fun kind -> prio kind > unwind_prio) block.path
+     with
+     | Some path ->
+         (* This might be an function argument label or a tuple's label,
+            we need to look ahead to be sure. *)
+         let align =
+           if in_arrow && config.i_align_params = Never then L else T
+         in
+         extend (KExpr target_prio) align path
+     | None -> make_infix tok block.path)
   in
   let (>>!) opt f = match opt with Some x -> x | None -> f () in
   handle_dotted block tok >>! fun () ->
@@ -1333,14 +1413,7 @@ let rec update_path config block stream tok =
           block.path
       in
       (match path with
-       | {kind = KBody(KVal|KType|KExternal) | KColon} :: _ ->
-           (match unwind_while (fun kind -> prio kind > prio_arrow) block.path
-            with
-            | Some path ->
-                extend (KExpr prio_colon)
-                  (if config.i_align_params = Never then L else T)
-                  path
-            | None -> make_infix tok block.path)
+       | {kind = KBody(KVal|KType|KExternal) | KColon} :: _ -> tuple_or_argument_label ()
        | {kind = KModule|KLet|KLetIn
                  | KAnd(KModule|KLet|KLetIn)} :: _ ->
            append KColon L path
@@ -1366,6 +1439,7 @@ let rec update_path config block stream tok =
             | _ -> make_infix tok block.path)
        | {kind = KBar KType} :: _ ->
            make_infix {tok with token = OF} block.path
+       | {kind = KParen; _} :: p when is_inside_type p -> tuple_or_argument_label ()
        | _ -> make_infix tok block.path)
 
   | SEMI ->

--- a/tests/passing/labeled-tuples.t
+++ b/tests/passing/labeled-tuples.t
@@ -95,9 +95,7 @@ in patterns:
     )
     -> x + y
 
-or in types. At the moment they arent as can be shown below.
-Labels should be indented at the same level than the '*' and the last
-element 'bool' and their arguments at one extra level.
+or in types:
 
   $ cat > test.ml << EOF
   > type t =
@@ -117,11 +115,11 @@ element 'bool' and their arguments at one extra level.
     (
       a:
         int
-        *
-        b:
+      *
+      b:
         string
-        *
-        bool
+      *
+      bool
     )
 
 Note that labeled tuples should be correctly handled even without the
@@ -143,11 +141,11 @@ parens and outside type declarations:
   let x :
     a:
       int
-      *
-      b:
+    *
+    b:
       string
-      *
-      bool
+    *
+    bool
     = y
 
 The priority between labels/colon, * and -> should be handled correctly
@@ -269,9 +267,9 @@ indented accordingly:
       int
       *
       b:
-      string
+        string
       *
       c:
-      string
+        string
     ->
     unit

--- a/tests/passing/labeled-tuples.t
+++ b/tests/passing/labeled-tuples.t
@@ -1,0 +1,277 @@
+Labeled tuples should be correctly indented, be it in
+expressions:
+
+  $ cat > test.ml << EOF
+  > (
+  > ~a:
+  > x
+  > ,
+  > ~b:
+  > y
+  > ,
+  > z
+  > )
+  > EOF
+
+  $ ocp-indent test.ml
+  (
+    ~a:
+      x
+    ,
+    ~b:
+      y
+    ,
+    z
+  )
+
+in patterns:
+
+  $ cat > test.ml << EOF
+  > match x with
+  > |
+  > (
+  > ~a
+  > ,
+  > ~b
+  > ,
+  > c
+  > )
+  > -> a + b + c
+  > |
+  > (
+  > ~a
+  > ,
+  > ..
+  > )
+  > -> a
+  > |
+  > (
+  > ~a:
+  > _
+  > ,
+  > ~b:
+  > (
+  > x
+  > ,
+  > y
+  > )
+  > ,
+  > _
+  > )
+  > -> x + y
+  > EOF
+
+  $ ocp-indent test.ml
+  match x with
+  |
+    (
+      ~a
+      ,
+      ~b
+      ,
+      c
+    )
+    -> a + b + c
+  |
+    (
+      ~a
+      ,
+      ..
+    )
+    -> a
+  |
+    (
+      ~a:
+        _
+      ,
+      ~b:
+        (
+          x
+          ,
+          y
+        )
+      ,
+      _
+    )
+    -> x + y
+
+or in types. At the moment they arent as can be shown below.
+Labels should be indented at the same level than the '*' and the last
+element 'bool' and their arguments at one extra level.
+
+  $ cat > test.ml << EOF
+  > type t =
+  > (
+  > a:
+  > int
+  > *
+  > b:
+  > string
+  > *
+  > bool
+  > )
+  > EOF
+
+  $ ocp-indent test.ml
+  type t =
+    (
+      a:
+        int
+        *
+        b:
+        string
+        *
+        bool
+    )
+
+Note that labeled tuples should be correctly handled even without the
+parens and outside type declarations:
+
+  $ cat > test.ml << EOF
+  > let x :
+  > a:
+  > int
+  > *
+  > b:
+  > string
+  > *
+  > bool
+  > = y
+  > EOF
+
+  $ ocp-indent test.ml
+  let x :
+    a:
+      int
+      *
+      b:
+      string
+      *
+      bool
+    = y
+
+The priority between labels/colon, * and -> should be handled correctly
+(-> has higher priority than * when "closing" a label block):
+
+  $ cat > test.ml << EOF
+  > let x : 
+  > a:
+  > int
+  > *
+  > string
+  > ->
+  > unit
+  > *
+  > b:
+  > string
+  > = y
+  > 
+  > (* should be indented as: *)
+  > 
+  > let x : 
+  > (
+  > a:
+  > (
+  > int
+  > *
+  > string
+  > )
+  > ->
+  > unit
+  > )
+  > *
+  > b:
+  > string
+  > 
+  > (* and not as: *)
+  > 
+  > let x : 
+  > a:
+  > (
+  > int
+  > *
+  > string
+  > ->
+  > unit
+  > )
+  > *
+  > b:
+  > string
+  > EOF
+
+  $ ocp-indent test.ml
+  let x : 
+    a:
+      int
+      *
+      string
+    ->
+    unit
+    *
+    b:
+      string
+    = y
+  
+  (* should be indented as: *)
+  
+  let x : 
+    (
+      a:
+        (
+          int
+          *
+          string
+        )
+      ->
+      unit
+    )
+    *
+    b:
+      string
+  
+  (* and not as: *)
+  
+  let x : 
+    a:
+      (
+        int
+        *
+        string
+        ->
+        unit
+      )
+    *
+    b:
+      string
+
+It is also important to note that the leftmost label is "paired" with the
+leftmost arrow when there is one. In the following example 'a' is a labeled
+argument and 'b' and 'c' are labeled tuple elements and they should therefore be
+indented accordingly:
+
+  $ cat > test.ml << EOF
+  > type t =
+  > a:
+  > int
+  > *
+  > b:
+  > string
+  > *
+  > c:
+  > string
+  > ->
+  > unit
+  > EOF
+
+  $ ocp-indent test.ml
+  type t =
+    a:
+      int
+      *
+      b:
+      string
+      *
+      c:
+      string
+    ->
+    unit

--- a/tests/passing/labeled-tuples.t
+++ b/tests/passing/labeled-tuples.t
@@ -273,3 +273,37 @@ indented accordingly:
         string
     ->
     unit
+
+The arrow lookahead should correctly handle code depths to avoid false
+positives:
+
+  $ cat > test.ml << EOF
+  > type t =
+  > a:
+  > int
+  > *
+  > (string -> unit)
+  > *
+  > b:
+  > (unit -> unit)
+  > *
+  > c:
+  >  < f: unit -> unit >
+  > 
+  > let x = 0
+  > EOF
+
+  $ ocp-indent test.ml
+  type t =
+    a:
+      int
+    *
+    (string -> unit)
+    *
+    b:
+      (unit -> unit)
+    *
+    c:
+      < f: unit -> unit >
+  
+  let x = 0


### PR DESCRIPTION
This PR adds tests for ocp-indent's behaviour with the labeled tuples syntax (introduced in OCaml 5.4: https://github.com/ocaml/ocaml/pull/13498).

In expressions and patterns, ocp-indent was already correctly handling labeled tuples and no update were required.

In type expressions though it didn't as the type expression syntax for labels was too closely tied to arrows which resulted in the incorrect indentation of the following example:
```ocaml
a:
int
*
b:
int
```
which was misintepreted as `a: (int * b:int)`, assuming the label `a` was a function argument label.

Properly handling this isn't a trivial fix since determining how to indent it ultimately depends on whether there is an arrow up ahead.

e.g.:
```ocaml
a:
int
*
b:
int
```
should be indented as follows:
```ocaml
a:
  int
*
b:
  int
```
but
```ocaml
a:
int
*
b:
int
-> unit
```
should be indented as follows:
```ocaml
a:
  int
  *
  b:
    int
-> unit
```
to reflect `->` and `*` priorities/associativity with the label.


`ocp-indent` doesn't handle backtracking and avoids lookahead as much as possible. I came to the conclusion that in this specific case, the lookahead was unavoidable so I tried to:
1. Avoid it as much as possible by eliminating unambiguously tuple cases: a label directly past a `*` cannot be associated with a `->`
2. Limit the lookahead search range and assume no arrow is coming up past it. In theory, the code could be arbitrarily long between a label and the arrow its associated with + the code can be incomplete.

I'll happily update and improve this approach based on user feedback. My gut feeling is that in practice this will work reasonably well though it might fail us in some corner cases.