### PR TITLE
Fix `strict_with` so it correctly applies to extensible variant types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   (#345, @NathanReb)
 + Add support for starred style comments (#347, @NathanReb)
 + Add explicit support for labeled tuples syntax (#349, @NathanReb)
++ Fix `strict_with` so it applies to extensible variant types in the
+  same way it applies to variant types (#350, @NathanReb)
 
 ## 1.9.0
 

--- a/src/ocp-indent-lib/indentBlock.ml
+++ b/src/ocp-indent-lib/indentBlock.ml
@@ -1396,7 +1396,25 @@ let rec update_path config block stream tok =
       in
       find_parent block.path
 
-  | COLONEQUAL | INFIXOP2 "+=" ->
+  | INFIXOP2 "+=" ->
+      (match
+         unwind_while (function KExpr _ | KType -> true | _ -> false) block.path
+       with
+       | Some ({kind=KType} as h::p) -> (* type t += *)
+           let indent =
+             match next_token stream with
+             | Some BAR when config.i_strict_with = Always -> config.i_with
+             | _ -> config.i_type
+           in
+           if starts_line then
+             let h = {h with indent = h.indent + indent; pad = 0} in
+             replace (KBody KType) L ~pad:0 (h :: p)
+           else
+             let h = {h with indent = h.column} in
+             replace (KBody KType) T ~pad:indent (h :: p)
+       | _ ->
+           make_infix tok block.path)
+  | COLONEQUAL ->
       (match
          unwind_while (function KExpr _ | KType -> true | _ -> false) block.path
        with

--- a/tests/passing/strict-with.t
+++ b/tests/passing/strict-with.t
@@ -75,8 +75,7 @@ should be indented, with 'always' they should be aligned the begining of the
   | A
   | B
 
-Same applies to extensible variant types (here we can see there is a bug as they
-are always indented, regardless of 'strict_with'):
+Same applies to extensible variant types:
 
   $ cat > test.ml << EOF
   > type t +=
@@ -96,5 +95,5 @@ are always indented, regardless of 'strict_with'):
 
   $ ocp-indent --config strict_with=always test.ml
   type t +=
-    | A
-    | B
+  | A
+  | B

--- a/tests/passing/strict-with.t
+++ b/tests/passing/strict-with.t
@@ -1,0 +1,100 @@
+Here we test the 'strict_with' configuration behaviour.
+
+strict_with tells whether a pattern matching case on its own line
+should be aligned with begining of the 'match ... with' line, regardless
+of whether 'match ... with' starts its own line or not.
+
+In the following example, 'match with' is on the same line as the
+'fun x ->'. Without 'strict_with=always', the case should be indented:
+
+  $ cat > test.ml << EOF
+  > fun x -> match x with
+  > | A -> a
+  > EOF
+
+  $ ocp-indent --config strict_with=never test.ml
+  fun x -> match x with
+    | A -> a
+
+  $ ocp-indent --config strict_with=auto test.ml
+  fun x -> match x with
+    | A -> a
+
+  $ ocp-indent --config strict_with=always test.ml
+  fun x -> match x with
+  | A -> a
+
+The following example is very similar but within a 'begin end' which
+is one of the exceptions of 'auto', meaning the case will only be indented if
+'strict_with=never':
+
+  $ cat > test.ml << EOF
+  > begin match x with
+  > | A -> a
+  > end
+  > EOF
+
+  $ ocp-indent --config strict_with=never test.ml
+  begin match x with
+    | A -> a
+  end
+
+  $ ocp-indent --config strict_with=auto test.ml
+  begin match x with
+  | A -> a
+  end
+
+  $ ocp-indent --config strict_with=always test.ml
+  begin match x with
+  | A -> a
+  end
+
+For consistent handling of '|', 'strict_with' also controls whether we indent
+variant type constructors. With 'never' and 'auto', the variant definitions
+should be indented, with 'always' they should be aligned the begining of the
+'type t =' line:
+
+  $ cat > test.ml << EOF
+  > type t =
+  > | A
+  > | B
+  > EOF
+
+  $ ocp-indent --config strict_with=never test.ml
+  type t =
+    | A
+    | B
+
+  $ ocp-indent --config strict_with=auto test.ml
+  type t =
+    | A
+    | B
+
+  $ ocp-indent --config strict_with=always test.ml
+  type t =
+  | A
+  | B
+
+Same applies to extensible variant types (here we can see there is a bug as they
+are always indented, regardless of 'strict_with'):
+
+  $ cat > test.ml << EOF
+  > type t +=
+  > | A
+  > | B
+  > EOF
+
+  $ ocp-indent --config strict_with=never test.ml
+  type t +=
+    | A
+    | B
+
+  $ ocp-indent --config strict_with=auto test.ml
+  type t +=
+    | A
+    | B
+
+  $ ocp-indent --config strict_with=always test.ml
+  type t +=
+    | A
+    | B


### PR DESCRIPTION
Fixes #348 